### PR TITLE
DOCSP-10188: add v1.7 branch

### DIFF
--- a/config/integration.yaml
+++ b/config/integration.yaml
@@ -9,9 +9,6 @@ zh:
 it:
   inherit: base
 base:
-  links:
-    - { 'v1.2': 'master' }
-    - { 'current': 'v1.2' }
   targets:
     - html
     - dirhtml

--- a/config/redirects
+++ b/config/redirects
@@ -1,6 +1,6 @@
 define: base https://docs.mongodb.com/php-library
 
 raw: php-library/ -> ${base}/current
-define version v1.1 v1.2 v1.3 v1.4 v1.5 v1.6 master
+define version v1.1 v1.2 v1.3 v1.4 v1.5 v1.6 v1.7 master
 symlink: upcoming -> master
 symlink: current -> v1.6


### PR DESCRIPTION
JIRA:
https://jira.mongodb.org/browse/DOCS-10188

- Added v1.7 (stable remains 1.6) and associated redirects
- Removed base/links entries since they are no longer used