### PR TITLE
DOCSP-11542: Update version in build_conf to correct title

### DIFF
--- a/config/build_conf.yaml
+++ b/config/build_conf.yaml
@@ -10,7 +10,7 @@ project:
   title: "PHP Library Manual"
   branched: true
 version:
-  release: '1.6'
+  release: '1.7'
   branch: 'master'
 system:
   runstate:


### PR DESCRIPTION
JIRA:
https://jira.mongodb.org/browse/DOCSP-11548

Staging:
https://docs-mongodbcom-staging.corp.mongodb.com/php-library/ccho/DOCSP-11542-update-v1.7-conf/reference/class/MongoDBCollection.html#phpclass.MongoDB\Collection

From some experimentation, it looks like config/build_conf.yaml contains an entry for version that needed to be updated for your v1.7 branch.