### PR TITLE
DOCSP-11548: update page title label to 1.8-dev for master branch

### DIFF
--- a/config/build_conf.yaml
+++ b/config/build_conf.yaml
@@ -10,7 +10,7 @@ project:
   title: "PHP Library Manual"
   branched: true
 version:
-  release: '1.6'
+  release: '1.8-dev'
   branch: 'master'
 system:
   runstate:


### PR DESCRIPTION
JIRA:
https://jira.mongodb.org/browse/DOCSP-11548

Staging:
https://docs-mongodborg-staging.corp.mongodb.com/php-library/ccho/DOCSP-11548-version-label/index.html