### PR TITLE
Update Makefile to point to DOP-owned AWS buckets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@ GIT_BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
 USER=$(shell whoami)
 STAGING_URL="https://docs-mongodborg-staging.corp.mongodb.com"
 PRODUCTION_URL="https://docs.mongodb.com"
-STAGING_BUCKET=docs-mongodb-org-staging
-PRODUCTION_BUCKET=docs-mongodb-org-prod
+STAGING_BUCKET=docs-mongodb-org-stg
+PRODUCTION_BUCKET=docs-mongodb-org-prd
 PROJECT=php-library
 
 # Parse our published-branches configuration file to get the name of


### PR DESCRIPTION
@terakilobyte This will shift the PHP docs to live in a DOP-owned AWS bucket rather than the monolithic and ancient 10gen-noc. We'll need this Makefile change backported to all of the phplib branches; if y'all could handle the cherry-picking and rebuilding, that would be ideal.

Guru should have already sent updated AWS credentials to use with Giza via 0bin.