### PR TITLE
DOCSP-20867: update redirects for versioned api and 1.10

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -5,4 +5,4 @@ define: versions v1.1 v1.2 v1.3 v1.4 v1.5 v1.6 v1.7 v1.8 v1.9 v1.10 master
 symlink: upcoming -> master
 symlink: current -> v1.10
 
-[v1.8-master]: ${prefix}/${version}/tutorials/versioned-api/ -> ${base}/${version}/tutorials/stable-api/
+[v1.9-master]: ${prefix}/${version}/tutorials/versioned-api/ -> ${base}/${version}/tutorials/stable-api/

--- a/config/redirects
+++ b/config/redirects
@@ -1,6 +1,8 @@
 define: base https://docs.mongodb.com/php-library
-
+define: prefix php-library
 raw: php-library/ -> ${base}/current
-define version v1.1 v1.2 v1.3 v1.4 v1.5 v1.6 v1.7 v1.8 v1.9 master
+define: versions v1.1 v1.2 v1.3 v1.4 v1.5 v1.6 v1.7 v1.8 v1.9 v1.10 master
 symlink: upcoming -> master
-symlink: current -> v1.9
+symlink: current -> v1.10
+
+[v1.8-master]: ${prefix}/${version}/tutorials/versioned-api/ -> ${base}/${version}/tutorials/stable-api/


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/DOCSP-20867

Output:
```sh
❯ mut-redirects config/redirects
Redirect 301 /php-library/ https://docs.mongodb.com/php-library/current
Redirect 301 /php-library/v1.9/tutorials/versioned-api/ https://docs.mongodb.com/php-library/v1.9/tutorials/stable-api/
Redirect 301 /php-library/v1.10/tutorials/versioned-api/ https://docs.mongodb.com/php-library/v1.10/tutorials/stable-api/
Redirect 301 /php-library/master/tutorials/versioned-api/ https://docs.mongodb.com/php-library/master/tutorials/stable-api/
```