### PR TITLE
DOP-3026: publish manifests to correct bucket/path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,8 @@ DOTCOM_PRODUCTION_URL="https://mongodb.com"
 DOTCOM_PRODUCTION_BUCKET=docs-mongodb-org-dotcomprd
 DOTCOM_PREFIX=docs/php-library
 DOTCOM_STGPREFIX=docs/php-library
+SEARCH_INDEX_BUCKET=docs-search-indexes-test
+
 
 # Parse our published-branches configuration file to get the name of
 # the current "stable" branch. This is weird and dumb, yes.
@@ -83,8 +85,8 @@ deploy: publish ## Deploy to the production bucket
 deploy-search-index: ## Update the search index for this branch
 	@echo "Building search index"
 	if [ ${STABLE_BRANCH} = ${GIT_BRANCH} ]; then \
-		mut-index upload build/public/${GIT_BRANCH} -o docs-php-library-${GIT_BRANCH}.json -u ${PRODUCTION_URL}/${PROJECT}/${GIT_BRANCH} -b ${PRODUCTION_BUCKET} -g -s; \
+		mut-index upload build/public/${GIT_BRANCH} -o docs-php-library-${GIT_BRANCH}.json -u ${PRODUCTION_URL}/${PROJECT}/${GIT_BRANCH} -b ${SEARCH_INDEX_BUCKET} -p search-indexes/prd -g -s; \
 	else \
-		mut-index upload build/public/${GIT_BRANCH} -o docs-php-library-${GIT_BRANCH}.json -u ${PRODUCTION_URL}/${PROJECT}/${GIT_BRANCH} -b ${PRODUCTION_BUCKET} -s; \
+		mut-index upload build/public/${GIT_BRANCH} -o docs-php-library-${GIT_BRANCH}.json -u ${PRODUCTION_URL}/${PROJECT}/${GIT_BRANCH} -b ${SEARCH_INDEX_BUCKET} -p search-indexes/prd -s; \
 	fi
 


### PR DESCRIPTION
Search is now using the docs-search-indexes-test bucket, not the old bucket(s) we were using previously. This updates the Makefile that y'all use for deploys to put the manifests into the right bucket.

I've manually copied the existing manifests over so that search will work as designed from the main docs search, this will just ensure that updates end up in the right place. You'll probably want to back-port the changes to the earlier editions that are actively maintained.


add this to the top:

SEARCH_INDEX_BUCKET=docs-search-indexes-test

replace the `-b` argument in the `mut-index` invocations with this:

-b ${SEARCH_INDEX_BUCKET} -p search-indexes/prd