### PR TITLE
DOCSP-26681 v1.1 backport - PHP version updates

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -1,0 +1,6 @@
+define: base https://www.mongodb.com/docs/php-library
+define: prefix docs/php-library
+raw: ${prefix}/ -> ${base}/current
+define: version v1.1 v1.2 v1.3 v1.4 v1.5 v1.6 v1.7 v1.8 v1.9 v1.10 v1.11 v1.12 v1.13 v1.15 master
+symlink: upcoming -> master
+symlink: current -> v1.15


### PR DESCRIPTION
(cherry picked from commit https://github.com/mongodb/docs-php-library/commit/c546f8eb50147f434c8d14a0ebdd6522a283d6d6)