### PR TITLE
Update the Makefile target to add the source/ directory if it doesn't exist already

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,8 @@ publish: ## Build docs locally
 
 	# get the latest for mongo-php-libray/docs git submodule:
 	git submodule update --remote --init
+	# create the source/ directory if it doesn't exist
+	mkdir -p source/
 	# rsync the docs source from the submodule to the source/ directory:
 	rsync -a --delete mongo-php-library/docs/ source/
 	# build the publish artefacts using giza:


### PR DESCRIPTION
Need to ensure that the "source/" path exists for the rsync command executed when using one of the make targets that depends on it. If it doesn't exist, the build will fail with an error that looks like the following:

```
giza make html
INFO:giza.operations.make:running sphinx build operation, equivalent to: giza sphinx --builder html
INFO:giza.content.assets:updated /Users/.../dev/docs-php-library/build/docs-tools repository
rsync: link_stat "/Users/.../dev/docs-php-library/source/." failed: No such file or directory (2)
rsync error: some files could not be transferred (code 23) at /AppleInternal/Library/BuildRoots/a0876c02-1788-11ed-b9c4-96898e02b808/Library/Caches/com.apple.xbs/Sources/rsync/rsync/main.c(996) [sender=2.6.9]
ERROR:giza.content.source:source transfer rsync had error: 23
```

By adding the "mkdir -p" command, you can ensure that the directory is created or noop if it already exists.