### PR TITLE
Update manual and php extlinks

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -56,8 +56,8 @@ rst_epilog = '\n'.join([
 
 extlinks = {
     'issue': ('https://jira.mongodb.org/browse/%s', '' ),
-    'manual': ('http://docs.mongodb.org/manual%s', ''),
-    'php': ('http://php.net/%s', '')
+    'manual': ('https://www.mongodb.com/docs/manual%s', ''),
+    'php': ('https://php.net/%s', '')
 }
 
 ## add `extlinks` for each published version.

--- a/conf.py
+++ b/conf.py
@@ -57,6 +57,7 @@ rst_epilog = '\n'.join([
 extlinks = {
     'issue': ('https://jira.mongodb.org/browse/%s', '' ),
     'manual': ('https://www.mongodb.com/docs/manual%s', ''),
+    'atlas': ('https://www.mongodb.com/docs/atlas%s', ''),
     'php': ('https://php.net/%s', '')
 }
 


### PR DESCRIPTION
Use https for both links and update "manual" to use the canonical docs URL