### PR TITLE
DOCSP-37038: Fix links (staging)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "mongo-php-library"]
 	path = mongo-php-library
-	url = https://github.com/norareidy/mongo-php-library.git
-	branch = DOCSP-37038-fix-broken-links
+	url = https://github.com/mongodb/mongo-php-library.git
+	branch = master

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "mongo-php-library"]
 	path = mongo-php-library
-	url = https://github.com/mongodb/mongo-php-library.git
-	branch = master
+	url = https://github.com/norareidy/mongo-php-library.git
+	branch = DOCSP-37038-fix-broken-links


### PR DESCRIPTION
JIRA - https://jira.mongodb.org/browse/DOCSP-37038
Staging - https://preview-mongodbnorareidy.gatsbyjs.io/php-library/DOCSP-37038/

Output from git submodule status:
` 280f20c37e1c55afe870e3259d5a13b05287aa53 mongo-php-library (1.17.0-55-g280f20c3)`

Output from git log on mongo-php-library:
```
commit 280f20c37e1c55afe870e3259d5a13b05287aa53 (HEAD -> master, upstream/master, origin/master, origin/HEAD)
Merge: 00d44d41 12ba7124
Author: Jeremy Mikola <jmikola@gmail.com>
Date:   Wed Feb 21 15:42:15 2024 -0500

    Merge branch 'v1.17'

commit 12ba7124f1cf1e3e32a374772eeccb65756388d1
Author: Nora Reidy <nora.reidy@mongodb.com>
Date:   Wed Feb 21 15:41:56 2024 -0500

    DOCSP-37038: Fix broken links (#1233)
```

