### PR TITLE
DOCSP-37915: add redirect from in-use encryption for 1.16

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -6,3 +6,4 @@ symlink: upcoming -> master
 symlink: current -> v1.17
 
 (v1.16-*]: ${prefix}/${version}/tutorial/client-side-encryption/ -> ${base}/${version}/tutorial/encryption/
+[v1.16]: ${prefix}/${version}/tutorial/encryption/ -> ${base}/${version}/


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/DOCSP-37915

Added redirect:
```
Redirect 301 /docs/php-library/v1.16/tutorial/encryption/ https://www.mongodb.com/docs/php-library/v1.16/
```