### PR TITLE
DOCSP-38363 - Make Functions a drawer only

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -1,15 +1,13 @@
 name = "php-library"
 title = "PHP Library Manual"
 
-intersphinx = [ "https://www.mongodb.com/docs/manual/objects.inv"
-              ]
+intersphinx = ["https://www.mongodb.com/docs/manual/objects.inv"]
 
 toc_landing_pages = [
     "/reference/class/MongoDBClient",
     "/reference/class/MongoDBCollection",
     "/reference/class/MongoDBDatabase",
     "/reference/class/MongoDBGridFSBucket",
-    "/reference/functions",
     "/reference/class/MongoDBBulkWriteResult",
     "/reference/class/MongoDBDeleteResult",
     "/reference/class/MongoDBInsertManyResult",
@@ -23,4 +21,3 @@ toc_landing_pages = [
 
 [substitutions]
 php-library = "MongoDB PHP Library"
-


### PR DESCRIPTION
This JIRA ticket identifies the PHP Functions page as having very little text. This PR makes it a drawer only, rather than a landing page.

JIRA: https://jira.mongodb.org/browse/DOCSP-38363

Staging: https://preview-mongodbmongokart.gatsbyjs.io/php-library/docsp-38363-delist-functions/reference/function/add_logger/