### PR TITLE
DOCSP-41495: php v1.20 compat updates

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "mongo-php-library"]
 	path = mongo-php-library
-	url = https://github.com/mongodb/mongo-php-library.git
-	branch = master
+	url = git@github.com:rustagir/mongo-php-library.git
+	branch = DOCSP-41495-php-server-eol

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "mongo-php-library"]
 	path = mongo-php-library
-	url = git@github.com:rustagir/mongo-php-library.git
+	url = https://github.com/rustagir/mongo-php-library.git
 	branch = DOCSP-41495-php-server-eol

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "mongo-php-library"]
 	path = mongo-php-library
-	url = https://github.com/rustagir/mongo-php-library.git
-	branch = DOCSP-41495-php-server-eol
+	url = https://github.com/mongodb/mongo-php-library.git
+	branch = master

--- a/README.rst
+++ b/README.rst
@@ -2,36 +2,23 @@
 MongoDB PHP Library Documentation
 =================================
 
-This repository contains documentation regarding the MongoDB PHP Library. This
-documentation builds on the work of the `MongoDB
-Manual <http://docs.mongodb.org/manual/>`_.
+This repository contains documentation for the MongoDB PHP Library
+component of the PHP Driver.
 
-Building the documentation requires `giza 
-<https://pypi.python.org/pypi/giza/>`_. 
+File JIRA Tickets
+-----------------
 
-If you already have `giza <https://pypi.python.org/pypi/giza/>`_
-installed, you can download and build this documentation locally with
-the following command: ::
+Please file issue reports or requests at the `Documentation Jira Project
+<https://jira.mongodb.org/browse/DOCS>`_.
 
-     git clone git://github.com/mongodb/docs-php-library
-     cd docs-php-library/
-     make publish
-
-View ``build/master/html/index.html`` to view your current build of the
-documentation.
-
-If you have not installed giza, you can do so with `pip`.
-
-To contribute to the documentation, please fork this repository on
-GitHub and issue a pull request. If you have not done so already,
-please sign the `MongoDB/10gen Contributor Agreement
-<https://www.mongodb.com/legal/contributor-agreement>`_.
+Licenses
+--------
 
 All documentation is available under the terms of a `Creative Commons
-License <http://creativecommons.org/licenses/by-nc-sa/3.0/>`_.
+License <https://creativecommons.org/licenses/by-nc-sa/3.0/>`_.
 
 The MongoDB Documentation Project is governed by the terms of the
-`MongoDB/10gen Contributor Agreement
+`MongoDB Contributor Agreement
 <https://www.mongodb.com/legal/contributor-agreement>`_.
 
 -- The MongoDB Docs Team

--- a/snooty.toml
+++ b/snooty.toml
@@ -21,3 +21,6 @@ toc_landing_pages = [
 
 [substitutions]
 php-library = "MongoDB PHP Library"
+
+[constants]
+php-library = "MongoDB PHP Library"


### PR DESCRIPTION
https://jira.mongodb.org/browse/DOCSP-41495

adds information about server compat updates

[staging](https://preview-mongodbrustagir.gatsbyjs.io/php-library/DOCSP-41495-php-server-eol/whats-new/)

[content PR](https://github.com/mongodb/mongo-php-library/pull/1364)