### PR TITLE
DOCSP-42026: In use encryption

### DIFF
--- a/source/index.txt
+++ b/source/index.txt
@@ -15,6 +15,7 @@ MongoDB PHP Library
    /write
    /aggregation
    /indexes
+   /security
    /tutorial
    /upgrade
    /reference

--- a/source/security.txt
+++ b/source/security.txt
@@ -1,0 +1,11 @@
+.. _php-security:
+
+================
+Secure Your Data
+================
+
+.. toctree::
+   :titlesonly:
+   :maxdepth: 1
+
+   /security/in-use-encryption

--- a/source/security/in-use-encryption.txt
+++ b/source/security/in-use-encryption.txt
@@ -73,8 +73,8 @@ Encryption </core/queryable-encryption/>` in the {+mdb-server+} manual.
 Client-side Field Level Encryption
 ----------------------------------
 
-Client-side Field Level Encryption (CSFLE) was introduced in MongoDB
-Server version 4.2 and supports searching encrypted fields for equality.
+Client-side Field Level Encryption (CSFLE) was introduced in {+mdb-server+}
+version 4.2 and supports searching encrypted fields for equality.
 CSFLE differs from Queryable Encryption in that you can select either a
 deterministic or random encryption algorithm to encrypt fields. You can only
 query encrypted fields that use a deterministic encryption algorithm when

--- a/source/security/in-use-encryption.txt
+++ b/source/security/in-use-encryption.txt
@@ -1,0 +1,101 @@
+.. _php-in-use-encryption:
+
+=================
+In-Use Encryption
+=================
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+.. facet::
+   :name: genre
+   :values: reference
+ 
+.. meta::
+   :keywords: qe, csfle, field level encryption
+
+Overview
+--------
+
+You can use the {+php-library+} to encrypt specific document fields by using a
+set of features called **in-use encryption**. In-use encryption allows
+your application to encrypt data *before* sending it to MongoDB
+and query documents with encrypted fields.
+
+In-use encryption prevents unauthorized users from viewing plaintext
+data as it is sent to MongoDB or while it is in an encrypted database. To
+enable in-use encryption in an application and authorize it to decrypt
+data, you must create encryption keys that only your application can
+access. Only applications that have access to your encryption
+keys can access the decrypted, plaintext data. If an attacker gains
+access to the database, they can see only the encrypted ciphertext data
+because they lack access to the encryption keys.
+
+You can use in-use encryption to encrypt fields in your MongoDB
+documents that contain the following types of sensitive data:
+
+- Credit card numbers
+- Addresses
+- Health information
+- Financial information
+- Any other sensitive or personally identifiable information (PII)
+
+MongoDB offers the following features to enable in-use encryption:
+
+- :ref:`Queryable Encryption <php-in-use-encryption-qe>`
+- :ref:`Client-side Field Level Encryption <php-in-use-encryption-csfle>`
+
+.. _php-in-use-encryption-qe:
+
+Queryable Encryption
+--------------------
+
+Queryable Encryption is the next-generation in-use encryption feature,
+first introduced as a preview feature in {+mdb-server+} version 6.0 and
+as a generally available (GA) feature in MongoDB 7.0. Queryable
+Encryption supports searching encrypted fields for equality and encrypts
+each value uniquely.
+
+.. important:: Preview Feature Incompatible with MongoDB 7.0
+   
+   The implementation of Queryable Encryption in MongoDB 6.0 is incompatible with
+   the GA version introduced in MongoDB 7.0. The Queryable Encryption preview 
+   feature is no longer supported.
+
+To learn more about Queryable Encryption, see :manual:`Queryable
+Encryption </core/queryable-encryption/>` in the {+mdb-server+} manual.
+
+.. _php-in-use-encryption-csfle:
+
+Client-side Field Level Encryption
+----------------------------------
+
+Client-side Field Level Encryption (CSFLE) was introduced in MongoDB
+Server version 4.2 and supports searching encrypted fields for equality.
+CSFLE differs from Queryable Encryption in that you can select either a
+deterministic or random encryption algorithm to encrypt fields. You can only
+query encrypted fields that use a deterministic encryption algorithm when
+using CSFLE. When you use a random encryption algorithm to encrypt
+fields in CSFLE, they can be decrypted, but you cannot perform equality
+queries on those fields. When you use Queryable Encryption, you cannot
+specify the encryption algorithm, but you can query all encrypted
+fields.
+
+When you deterministically encrypt a value, the same input value
+produces the same output value. While deterministic encryption allows
+you to perform queries on those encrypted fields, encrypted data with
+low cardinality is susceptible to code breaking by frequency analysis.
+
+.. tip::
+
+   To learn more about these concepts, see the following Wikipedia
+   entries:
+
+   - :wikipedia:`Cardinality <w/index.php?title=Cardinality_(data_modeling)&oldid=1182661589>`
+   - :wikipedia:`Frequency Analysis <w/index.php?title=Frequency_analysis&oldid=1182536787>`
+
+To learn more about CSFLE, see :manual:`CSFLE </core/csfle/>` in the {+mdb-server+}
+manual.


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-php-library/blob/master/REVIEWING.md)

Mostly identical to the [C++ In-Use Encryption](https://www.mongodb.com/docs/languages/cpp/cpp-driver/upcoming/security/in-use-encryption/) page

JIRA - https://jira.mongodb.org/browse/DOCSP-42026
Staging - https://deploy-preview-142--docs-php-library.netlify.app/security/in-use-encryption/

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [ ] Are all the links working?
- [ ] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
