### PR TITLE
Revise descriptions for server opening/closed events

### DIFF
--- a/source/monitoring/cluster-monitoring.txt
+++ b/source/monitoring/cluster-monitoring.txt
@@ -100,10 +100,10 @@ documentation, and a description of when the event is published:
        type changing from secondary to primary.
 
    * - :php:`ServerOpeningEvent <mongodb-driver-monitoring-serveropeningevent>`
-     - Created when a server connection is established.
+     - Created when a new server is added to the topology.
 
    * - :php:`ServerClosedEvent <mongodb-driver-monitoring-serverclosedevent>`
-     - Created when a server connection is closed.
+     - Created when an existing server is removed from the topology.
 
    * - :php:`TopologyChangedEvent <mongodb-driver-monitoring-topologychangedevent>`
      - Created when the topology description changes, such as when there


### PR DESCRIPTION
After [DOCSP-41982](https://jira.mongodb.org/browse/DOCSP-41982) was completed, I opened [PHPC-2449](https://jira.mongodb.org/browse/PHPC-2449) to improve the PHP.net docs. While doing so, I realized the original descriptions for these events were inaccurate.

This is based on changes in https://github.com/php/doc-en/pull/3802

Note that there are additional caveats for the topology open/closed events (the driver's client persistence behavior may get in the way of observing them), but I don't think we need to discuss that in this tutorial.