### PR TITLE
(DOCSP-44298) [PHP Library]: update changelogs to remove updates for EOL'd versions v1.16 & earlier

### DIFF
--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -28,10 +28,6 @@ following versions of the {+php-library+}:
 
 * :ref:`Version 1.17 <php-lib-version-1.17>`
 
-* :ref:`Version 1.16 <php-lib-version-1.16>`
-
-* :ref:`Version 1.15 <php-lib-version-1.15>`
-
 .. _php-lib-version-1.20:
 
 What's New in 1.20
@@ -119,40 +115,3 @@ What's New in 1.17
 
 To learn more about this release, see the `v1.17 Release Notes 
 <https://github.com/mongodb/mongo-php-library/releases/tag/1.17.0>`__ on GitHub.
-
-.. _php-lib-version-1.16:
-
-What's New in 1.16
-------------------
-
-- Introduces support for :v7.0:`MongoDB 7.0 </release-notes/7.0>`. 
-
-- Introduces :phpmethod:`MongoDB\Database::createEncryptedCollection()`. 
-  This method automatically creates data encryption keys when creating a new 
-  encrypted collection.
-
-- Upgrades the ``mongodb`` extension requirement to 1.16.0.
-
-To learn more about this release, see the `v1.16 Release Notes 
-<https://github.com/mongodb/mongo-php-library/releases/tag/1.16.0>`__ on GitHub.
-
-.. _php-lib-version-1.15:
-
-What's New in 1.15
-------------------
-
-- Adds new ``examples/`` and ``tools/`` directories to the library repository, 
-  which contain code snippets and scripts that may prove useful when writing 
-  or debugging applications. These directories are intended to 
-  supplement the library's existing documentation and will be added to over time.
-
-- Adds various backwards compatible typing improvements throughout the
-  library. Downstream impact for these changes are discussed in 
-  `UPGRADE-1.15.md <https://github.com/mongodb/mongo-php-library/blob/1.15.0/UPGRADE-1.15.md>`__. 
-  
-- Integrates `Psalm <https://psalm.dev/>`__ for static analysis.
-
-- Upgrades the ``mongodb`` extension requirement to 1.15.0.
-
-To learn more about this release, see the `v1.15 Release Notes 
-<https://github.com/mongodb/mongo-php-library/releases/tag/1.15.0>`__ on GitHub.


### PR DESCRIPTION
# Pull Request Info
v1.16 has reached it's end-of-life per the archival policy (linked in Epic). Release notes for this version and all earlier versions should also be removed from current versions (v1.17 and later). This preserves the changelog information in the original versions (e.g. v1.15 notes are in the v1.15 changelog, but not later versions).

[PR Reviewing Guidelines](https://github.com/mongodb/docs-php-library/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-44298>
Staging - <https://deploy-preview-165--docs-php-library.netlify.app/whats-new/>

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
- [ ] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
