### PR TITLE
(DOCSP-45749) Denests last phase 1 nested components

### DIFF
--- a/source/reference/method/MongoDBDatabase-createCollection.txt
+++ b/source/reference/method/MongoDBDatabase-createCollection.txt
@@ -64,9 +64,8 @@ Parameters
        - Specify ``false`` to disable the automatic creation of an index on the
          ``_id`` field.
 
-         .. important::
-
-            For replica sets, do not set ``autoIndexId`` to ``false``.
+         :gold:`IMPORTANT:` For replica sets, do not set
+         ``autoIndexId`` to ``false``.
 
          .. deprecated:: 1.4
             This option has been deprecated since MongoDB 3.2. As of MongoDB
@@ -242,10 +241,8 @@ Parameters
        - Determines whether to ``error`` on invalid documents or just ``warn``
          about the violations but allow invalid documents to be inserted.
 
-         .. important::
-
-            Validation of documents only applies to those documents as
-            determined by the ``validationLevel``.
+         :gold:`IMPORTANT:` Validation of documents only applies to
+         those documents as determined by the ``validationLevel``.
 
          .. list-table::
             :header-rows: 1


### PR DESCRIPTION
# Pull Request Info

No changes to content except denesting nested admonitions.
Build log has a temporary buildhooks error which are nonblocking per DOP, see Slack conversation verifying this: https://mongodb.slack.com/archives/C018UTGP23T/p1733237894795969

[PR Reviewing Guidelines](https://github.com/mongodb/docs-php-library/blob/master/REVIEWING.md)

JIRA - https://jira.mongodb.org/browse/DOCSP-45749
Staging - 

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
- [ ] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
