### PR TITLE
DOCSP-44237 flags Option deprecation on v2.21

### DIFF
--- a/source/reference/method/MongoDBDatabase-createCollection.txt
+++ b/source/reference/method/MongoDBDatabase-createCollection.txt
@@ -152,6 +152,12 @@ Parameters
          :manual:`db.createCollection()
          </reference/method/db.createCollection>` for more information.
 
+         *Deprecated*: This option is deprecated and will be removed in 
+         {+php-library+} v2.0. For more information on upgrading from the MMAPv1 storage 
+         engine to Wired Tiger, see the 
+         :manual:`Change a Self-Managed Standalone to WiredTiger </tutorial/change-standalone-wiredtiger/>` 
+         guide.
+
      * - indexOptionDefaults
        - array|object
        - Allows users to specify a default configuration for indexes when

--- a/source/reference/method/MongoDBDatabase-createCollection.txt
+++ b/source/reference/method/MongoDBDatabase-createCollection.txt
@@ -153,10 +153,10 @@ Parameters
          </reference/method/db.createCollection>` for more information.
 
          *Deprecated*: This option is deprecated and will be removed in 
-         {+php-library+} v2.0. For more information on upgrading from the MMAPv1 storage 
-         engine to Wired Tiger, see the 
+         the v2.0 {+library-short+} release. To learn more about upgrading 
+         from the MMAPv1 storage engine to Wired Tiger, see the 
          :manual:`Change a Self-Managed Standalone to WiredTiger </tutorial/change-standalone-wiredtiger/>` 
-         guide.
+         guide in the Server manual.
 
      * - indexOptionDefaults
        - array|object

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -49,8 +49,8 @@ improvements, and fixes:
   replaced by these new methods in a future driver release, so consider
   changing the usages in your application.
 
-- The ``flags`` field, used for the deprecated MMAPv1 storage engine, is now 
-  deprecated and will be removed in {+library-short+} v2.0.
+- Deprecates the ``flags`` option, used for the deprecated MMAPv1 storage engine. 
+  This option will be removed in {+library-short+} v2.0.
 
 .. _php-lib-version-1.20:
 

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -49,6 +49,9 @@ improvements, and fixes:
   replaced by these new methods in a future driver release, so consider
   changing the usages in your application.
 
+- The ``flags`` field, used for the deprecated MMAPv1 storage engine, is now 
+  deprecated and will be removed in {+library-short+} v2.0.
+
 .. _php-lib-version-1.20:
 
 What's New in 1.20


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-php-library/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-44237>
Staging - <https://deploy-preview-201--docs-php-library.netlify.app/reference/method/MongoDBDatabase-createCollection/#:~:text=version%201.9.-,flags,-integer>

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
- [x] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
