### PR TITLE
DOCSP-47864: sort order for updateone / replaceone

### DIFF
--- a/source/reference/method/MongoDBCollection-bulkWrite.txt
+++ b/source/reference/method/MongoDBCollection-bulkWrite.txt
@@ -141,11 +141,11 @@ Behavior
 .. include:: /includes/extracts/bulkwriteexception-result.rst
 .. include:: /includes/extracts/bulkwriteexception-ordered.rst
 
-.. todo: add output and examples
-
 See Also
 --------
 
+- :ref:`php-bulk-write`
+- :ref:`php-write`
 - :phpmethod:`MongoDB\Collection::deleteMany()`
 - :phpmethod:`MongoDB\Collection::deleteOne()`
 - :phpmethod:`MongoDB\Collection::insertMany()`
@@ -153,4 +153,3 @@ See Also
 - :phpmethod:`MongoDB\Collection::replaceOne()`
 - :phpmethod:`MongoDB\Collection::updateMany()`
 - :phpmethod:`MongoDB\Collection::updateOne()`
-- :ref:`php-write`

--- a/source/reference/method/MongoDBCollection-replaceOne.txt
+++ b/source/reference/method/MongoDBCollection-replaceOne.txt
@@ -2,7 +2,6 @@
 MongoDB\\Collection::replaceOne()
 =================================
 
-
 .. contents:: On this page
    :local:
    :backlinks: none
@@ -88,6 +87,14 @@ Parameters
        - .. include:: /includes/extracts/common-option-session.rst
 
          .. versionadded:: 1.3
+
+     * - sort
+       - array|object
+       - The sort specification for the ordering of the matched
+         documents. Set this option to apply an order to matched
+         documents before the server performs the replace operation.
+
+         .. versionadded:: 1.21
 
      * - upsert
        - boolean

--- a/source/reference/method/MongoDBCollection-updateOne.txt
+++ b/source/reference/method/MongoDBCollection-updateOne.txt
@@ -2,7 +2,6 @@
 MongoDB\\Collection::updateOne()
 ================================
 
-
 .. contents:: On this page
    :local:
    :backlinks: none
@@ -93,6 +92,14 @@ Parameters
        - .. include:: /includes/extracts/common-option-session.rst
 
          .. versionadded:: 1.3
+
+     * - sort
+       - array|object
+       - The sort specification for the ordering of the matched
+         documents. Set this option to apply an order to matched
+         documents before the server performs the update operation.
+
+         .. versionadded:: 1.21
 
      * - upsert
        - boolean

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -149,6 +149,11 @@ improvements, and fixes:
 - Deprecates the ``flags`` option, used for the deprecated MMAPv1 storage engine. 
   This option will be removed in {+library-short+} v2.0.
 
+- Adds a sort option to the :phpmethod:`MongoDB\Collection::updateOne()`
+  and :phpmethod:`MongoDB\Collection::replaceOne()` methods. This
+  change also allows you to set a sort order as an option when performing
+  update and replace operations in a bulk operation.
+
 For more information about the changes in this version, see the
 :github:`v1.21 release notes
 </mongodb/mongo-php-library/releases/tag/1.21.0>` on GitHub.

--- a/source/write/replace.txt
+++ b/source/write/replace.txt
@@ -153,6 +153,10 @@ table describes some options you can set in the array:
          Server manual.
        | Defaults to ``false``.
 
+   * - ``sort``
+     - | Specifies the sort order to apply to documents before
+         performing the replace operation.
+
    * - ``collation``
      - | Specifies the kind of language collation to use when sorting
          results. For more information, see :manual:`Collation </reference/collation/#std-label-collation>`

--- a/source/write/update.txt
+++ b/source/write/update.txt
@@ -119,6 +119,10 @@ describes some options you can set in the array:
          Server manual.
        | Defaults to ``false``.
 
+   * - ``sort``
+     - | Applies to ``updateOne()`` only. Specifies the sort order to
+         apply to documents before performing the update operation.
+
    * - ``collation``
      - | Specifies the kind of language collation to use when sorting
          results. For more information, see :manual:`Collation </reference/collation/#std-label-collation>`


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-php-library/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-47864>
Staging - 
https://deploy-preview-209--docs-php-library.netlify.app/reference/method/MongoDBCollection-updateOne/#parameters
https://deploy-preview-209--docs-php-library.netlify.app/reference/method/MongoDBCollection-replaceOne/#parameters
https://deploy-preview-209--docs-php-library.netlify.app/whats-new/#std-label-php-lib-version-1.21

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
- [x] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
