### PR TITLE
DOCSP-47835 Clarify batchsize behavior

### DIFF
--- a/source/includes/extracts-watch-option.yaml
+++ b/source/includes/extracts-watch-option.yaml
@@ -1,10 +1,15 @@
 ref: watch-option-batchSize
 content: |
-  The maximum number of documents within each batch returned in a query result, which applies 
+  The maximum number of documents within each batch returned in a change stream, which applies 
   to the ``aggregate`` command. By default, the ``aggregate`` command has an initial batch size of 
   ``101`` documents and a maximum size of 16 mebibytes (MiB) for each subsequent batch. This
   option can enforce a smaller limit than 16 MiB, but not a larger one. If you set ``batchSize`` 
   to a limit that results in batches larger than 16 MiB, this option has no effect.
+
+  Irrespective of the ``batchSize`` option, the initial ``aggregate`` command
+  response for a change stream generally does not include any documents
+  unless another option is used to configure its starting point (e.g.
+  ``startAfter``).
 ---
 ref: watch-option-fullDocument
 content: |

--- a/source/includes/extracts-watch-option.yaml
+++ b/source/includes/extracts-watch-option.yaml
@@ -2,13 +2,9 @@ ref: watch-option-batchSize
 content: |
   The maximum number of documents within each batch returned in a query result, which applies 
   to the ``aggregate`` command. By default, the ``aggregate`` command has an initial batch size of 
-  ``101`` documents and a maximum size of 16 mebibytes for each subsequent batch. This
-  option can enforce a smaller limit than 16 mebibytes, but not a larger
-  one. If you set ``batchSize`` to a limit that results in batches larger than
-  16 MiB, this option has no effect.
-
-  This command determines the maximum number of change events to return in each response from the
-  server.
+  ``101`` documents and a maximum size of 16 mebibytes (MiB) for each subsequent batch. This
+  option can enforce a smaller limit than 16 MiB, but not a larger one. If you set ``batchSize`` 
+  to a limit that results in batches larger than 16 MiB, this option has no effect.
 ---
 ref: watch-option-fullDocument
 content: |

--- a/source/includes/extracts-watch-option.yaml
+++ b/source/includes/extracts-watch-option.yaml
@@ -1,16 +1,14 @@
 ref: watch-option-batchSize
 content: |
-  The maximum number of documents within each batch returned in a query result. By default,
-  the ``find()`` method has an initial batch size of ``101`` documents
-  and a maximum of 16 megabytes for each subsequent batch. This
-  option can enforce a smaller limit than 16 megabytes, but not a larger
+  The maximum number of documents within each batch returned in a query result, which applies 
+  to the ``aggregate`` command. By default, the ``aggregate`` command has an initial batch size of 
+  ``101`` documents and a maximum size of 16 mebibytes for each subsequent batch. This
+  option can enforce a smaller limit than 16 mebibytes, but not a larger
   one. If you set ``batchSize`` to a limit that results in batches larger than
-  16 MB, this option has no effect.
+  16 MiB, this option has no effect.
 
-  Irrespective of the ``batchSize`` option, the initial ``aggregate`` command
-  response for a change stream generally does not include any documents
-  unless another option is used to configure its starting point (e.g.
-  ``startAfter``).
+  This command determines the maximum number of change events to return in each response from the
+  server.
 ---
 ref: watch-option-fullDocument
 content: |

--- a/source/includes/extracts-watch-option.yaml
+++ b/source/includes/extracts-watch-option.yaml
@@ -1,9 +1,11 @@
 ref: watch-option-batchSize
 content: |
-  Specifies the batch size for the cursor, which will apply to both the initial
-  ``aggregate`` command and any subsequent ``getMore`` commands. This determines
-  the maximum number of change events to return in each response from the
-  server.
+
+  Specifies the batch size for the cursor, which will apply to both the
+  initial ``aggregate`` command and any subsequent ``getMore`` commands.
+  If batchSize is set, ``aggregate`` and any subsequent ``getMore`` commands returns the smaller of 16 megabytes of data 
+  or batchSize documents. Operations of type ``find()``, ``aggregate()``, ``listIndexes``, and ``listCollections`` return a maximum of ``16`` megabytes per batch. 
+  batchSize can enforce a smaller limit than ``16`` megabytes, but not a larger one. 
 
   Irrespective of the ``batchSize`` option, the initial ``aggregate`` command
   response for a change stream generally does not include any documents

--- a/source/includes/extracts-watch-option.yaml
+++ b/source/includes/extracts-watch-option.yaml
@@ -4,7 +4,7 @@ content: |
   Specifies the batch size for the cursor, which will apply to both the
   initial ``aggregate`` command and any subsequent ``getMore`` commands.
   If batchSize is set, ``aggregate`` and any subsequent ``getMore`` commands returns the smaller of 16 megabytes of data 
-  or batchSize documents. Operations of type ``find()``, ``aggregate()``, ``listIndexes``, and ``listCollections`` return a maximum of ``16`` megabytes per batch. 
+  or batchSize documents. Operations of type ``find``, ``aggregate``, ``listIndexes``, and ``listCollections`` return a maximum of ``16`` megabytes per batch. 
   batchSize can enforce a smaller limit than ``16`` megabytes, but not a larger one. 
 
   Irrespective of the ``batchSize`` option, the initial ``aggregate`` command

--- a/source/includes/extracts-watch-option.yaml
+++ b/source/includes/extracts-watch-option.yaml
@@ -1,11 +1,11 @@
 ref: watch-option-batchSize
 content: |
-
-  Specifies the batch size for the cursor, which will apply to both the
-  initial ``aggregate`` command and any subsequent ``getMore`` commands.
-  If batchSize is set, ``aggregate`` and any subsequent ``getMore`` commands returns the smaller of 16 megabytes of data 
-  or batchSize documents. Operations of type ``find``, ``aggregate``, ``listIndexes``, and ``listCollections`` return a maximum of ``16`` megabytes per batch. 
-  batchSize can enforce a smaller limit than ``16`` megabytes, but not a larger one. 
+  The maximum number of documents within each batch returned in a query result. By default,
+  the ``find()`` method has an initial batch size of ``101`` documents
+  and a maximum of 16 megabytes for each subsequent batch. This
+  option can enforce a smaller limit than 16 megabytes, but not a larger
+  one. If you set ``batchSize`` to a limit that results in batches larger than
+  16 MB, this option has no effect.
 
   Irrespective of the ``batchSize`` option, the initial ``aggregate`` command
   response for a change stream generally does not include any documents

--- a/source/read/retrieve.txt
+++ b/source/read/retrieve.txt
@@ -182,10 +182,10 @@ you can set in the array:
    * - ``batchSize`` 
      - | The maximum number of documents within each batch returned in a query result. By default,
          the ``find()`` method has an initial batch size of ``101`` documents
-         and a maximum of 16 megabytes for each subsequent batch. This
-         option can enforce a smaller limit than 16 megabytes, but not a larger
+         and a maximum size of 16 mebibytes for each subsequent batch. This
+         option can enforce a smaller limit than 16 mebibytes, but not a larger
          one. If you set ``batchSize`` to a limit that results in batches larger than
-         16 MB, this option has no effect.
+         16 MiB, this option has no effect.
        | **Type**: ``integer``
 
    * - ``collation`` 

--- a/source/read/retrieve.txt
+++ b/source/read/retrieve.txt
@@ -181,7 +181,7 @@ you can set in the array:
 
    * - ``batchSize`` 
      - | The maximum number of documents within each batch returned in a query result. By default,
-         the ``find()`` method has an initial batch size of ``101`` documents
+         the ``find`` command has an initial batch size of ``101`` documents
          and a maximum size of 16 mebibytes (MiB) for each subsequent batch. This
          option can enforce a smaller limit than 16 MiB, but not a larger
          one. If you set ``batchSize`` to a limit that results in batches larger than

--- a/source/read/retrieve.txt
+++ b/source/read/retrieve.txt
@@ -182,8 +182,8 @@ you can set in the array:
    * - ``batchSize`` 
      - | The maximum number of documents within each batch returned in a query result. By default,
          the ``find()`` method has an initial batch size of ``101`` documents
-         and a maximum size of 16 mebibytes for each subsequent batch. This
-         option can enforce a smaller limit than 16 mebibytes, but not a larger
+         and a maximum size of 16 mebibytes (MiB) for each subsequent batch. This
+         option can enforce a smaller limit than 16 MiB, but not a larger
          one. If you set ``batchSize`` to a limit that results in batches larger than
          16 MiB, this option has no effect.
        | **Type**: ``integer``

--- a/source/read/retrieve.txt
+++ b/source/read/retrieve.txt
@@ -180,7 +180,9 @@ you can set in the array:
      - Description
 
    * - ``batchSize`` 
-     - | The number of documents to return per batch. The default value is ``101``.
+     - | The limit for each batch returned in a query result. The ``find()`` method has an initial batch size of 101 documents by default and returns a maximum of 16
+         megabytes per batch. Subsequent ``getMore`` operations issued against the resulting cursor have no default batch size, 
+         so they are limited only by the ``16`` megabyte message size. batchSize can enforce a smaller limit than ``16`` megabytes, but not a larger one. 
        | **Type**: ``integer``
 
    * - ``collation`` 

--- a/source/read/retrieve.txt
+++ b/source/read/retrieve.txt
@@ -180,9 +180,12 @@ you can set in the array:
      - Description
 
    * - ``batchSize`` 
-     - | The limit for each batch returned in a query result. The ``find`` method has an initial batch size of ``101`` documents by default and returns a maximum of 16
-         megabytes per batch. Subsequent ``getMore`` operations issued against the resulting cursor have no default batch size, 
-         so they are limited only by the ``16`` megabyte message size. batchSize can enforce a smaller limit than ``16`` megabytes, but not a larger one. 
+     - | The maximum number of documents within each batch returned in a query result. By default,
+         the ``find()`` method has an initial batch size of ``101`` documents
+         and a maximum of 16 megabytes for each subsequent batch. This
+         option can enforce a smaller limit than 16 megabytes, but not a larger
+         one. If you set ``batchSize`` to a limit that results in batches larger than
+         16 MB, this option has no effect.
        | **Type**: ``integer``
 
    * - ``collation`` 

--- a/source/read/retrieve.txt
+++ b/source/read/retrieve.txt
@@ -180,7 +180,7 @@ you can set in the array:
      - Description
 
    * - ``batchSize`` 
-     - | The limit for each batch returned in a query result. The ``find()`` method has an initial batch size of 101 documents by default and returns a maximum of 16
+     - | The limit for each batch returned in a query result. The ``find`` method has an initial batch size of ``101`` documents by default and returns a maximum of 16
          megabytes per batch. Subsequent ``getMore`` operations issued against the resulting cursor have no default batch size, 
          so they are limited only by the ``16`` megabyte message size. batchSize can enforce a smaller limit than ``16`` megabytes, but not a larger one. 
        | **Type**: ``integer``

--- a/source/reference/method/MongoDBCollection-find.txt
+++ b/source/reference/method/MongoDBCollection-find.txt
@@ -52,9 +52,8 @@ Parameters
 
      * - batchSize
        - integer
-       - The maximum number of documents within each batch returned in a query result, which applies 
-         to the ``aggregate`` command. By default, the ``aggregate`` command has an initial batch size of 
-         `101`` documents and a maximum size of 16 mebibytes for each subsequent batch. This
+       - The maximum number of documents to return in the first batch. By default, the ``find()`` 
+         command has an initial batch size of `101`` documents. This
          option can enforce a smaller limit than 16 mebibytes, but not a larger
          one. If you set ``batchSize`` to a limit that results in batches larger than
          16 MiB, this option has no effect.

--- a/source/reference/method/MongoDBCollection-find.txt
+++ b/source/reference/method/MongoDBCollection-find.txt
@@ -52,8 +52,8 @@ Parameters
 
      * - batchSize
        - integer
-       - The number of documents to return in the first batch. Defaults to
-         ``101``. A batchSize of ``0`` means that the cursor will be
+       - Sets the number of documents to return in the first batch if the number of documents to return is over ``101``.
+         Defaults to `101``. A batchSize of ``0`` means that the cursor will be
          established, but no documents will be returned in the first batch.
 
          Unlike the previous wire protocol version, a batchSize of ``1`` for the

--- a/source/reference/method/MongoDBCollection-find.txt
+++ b/source/reference/method/MongoDBCollection-find.txt
@@ -54,13 +54,13 @@ Parameters
        - integer
        - The maximum number of documents to return in the first batch. By default, the ``find()`` 
          command has an initial batch size of ``101`` documents. This
-         option can enforce a smaller limit than 16 mebibytes, but not a larger
+         option can enforce a smaller limit than 16 mebibytes (MiB), but not a larger
          one. If you set ``batchSize`` to a limit that results in batches larger than
          16 MiB, this option has no effect.
 
          A batchSize of ``0`` means that the cursor will be established, but no documents 
          will be returned in the first batch. This may be useful for quickly returning a cursor
-         or failure from ``aggregate`` without doing significant server-side work.
+         or failure without doing significant server-side work.
 
          Unlike the previous wire protocol version, a batchSize of ``1`` for the
          :dbcommand:`find` command does not close the cursor.

--- a/source/reference/method/MongoDBCollection-find.txt
+++ b/source/reference/method/MongoDBCollection-find.txt
@@ -54,7 +54,7 @@ Parameters
        - integer
        - The maximum number of documents within each batch returned in a query result. By default, the ``find`` 
          command has an initial batch size of ``101`` documents and a maximum size of 16 mebibytes (MiB)
-         for each subsequent batch. This option can enforce a smaller limit than 16 mebibytes (MiB), but not a larger
+         for each subsequent batch. This option can enforce a smaller limit than 16 MiB, but not a larger
          one. If you set ``batchSize`` to a limit that results in batches larger than
          16 MiB, this option has no effect.
 

--- a/source/reference/method/MongoDBCollection-find.txt
+++ b/source/reference/method/MongoDBCollection-find.txt
@@ -52,9 +52,12 @@ Parameters
 
      * - batchSize
        - integer
-       - Sets the number of documents to return in the first batch if the number of documents to return is over ``101``.
-         Defaults to ``101``. A batchSize of ``0`` means that the cursor will be
-         established, but no documents will be returned in the first batch.
+       - The maximum number of documents within each batch returned in a query result. By default,
+         the ``find()`` method has an initial batch size of ``101`` documents
+         and a maximum of 16 megabytes for each subsequent batch. This
+         option can enforce a smaller limit than 16 megabytes, but not a larger
+         one. If you set ``batchSize`` to a limit that results in batches larger than
+         16 MB, this option has no effect.
 
          Unlike the previous wire protocol version, a batchSize of ``1`` for the
          :dbcommand:`find` command does not close the cursor.

--- a/source/reference/method/MongoDBCollection-find.txt
+++ b/source/reference/method/MongoDBCollection-find.txt
@@ -53,7 +53,7 @@ Parameters
      * - batchSize
        - integer
        - The maximum number of documents to return in the first batch. By default, the ``find()`` 
-         command has an initial batch size of `101`` documents. This
+         command has an initial batch size of ``101`` documents. This
          option can enforce a smaller limit than 16 mebibytes, but not a larger
          one. If you set ``batchSize`` to a limit that results in batches larger than
          16 MiB, this option has no effect.

--- a/source/reference/method/MongoDBCollection-find.txt
+++ b/source/reference/method/MongoDBCollection-find.txt
@@ -53,7 +53,7 @@ Parameters
      * - batchSize
        - integer
        - Sets the number of documents to return in the first batch if the number of documents to return is over ``101``.
-         Defaults to `101``. A batchSize of ``0`` means that the cursor will be
+         Defaults to ``101``. A batchSize of ``0`` means that the cursor will be
          established, but no documents will be returned in the first batch.
 
          Unlike the previous wire protocol version, a batchSize of ``1`` for the

--- a/source/reference/method/MongoDBCollection-find.txt
+++ b/source/reference/method/MongoDBCollection-find.txt
@@ -52,12 +52,16 @@ Parameters
 
      * - batchSize
        - integer
-       - The maximum number of documents within each batch returned in a query result. By default,
-         the ``find()`` method has an initial batch size of ``101`` documents
-         and a maximum of 16 megabytes for each subsequent batch. This
-         option can enforce a smaller limit than 16 megabytes, but not a larger
+       - The maximum number of documents within each batch returned in a query result, which applies 
+         to the ``aggregate`` command. By default, the ``aggregate`` command has an initial batch size of 
+         `101`` documents and a maximum size of 16 mebibytes for each subsequent batch. This
+         option can enforce a smaller limit than 16 mebibytes, but not a larger
          one. If you set ``batchSize`` to a limit that results in batches larger than
-         16 MB, this option has no effect.
+         16 MiB, this option has no effect.
+
+         A batchSize of ``0`` means that the cursor will be established, but no documents 
+         will be returned in the first batch. This may be useful for quickly returning a cursor
+         or failure from ``aggregate`` without doing significant server-side work.
 
          Unlike the previous wire protocol version, a batchSize of ``1`` for the
          :dbcommand:`find` command does not close the cursor.

--- a/source/reference/method/MongoDBCollection-find.txt
+++ b/source/reference/method/MongoDBCollection-find.txt
@@ -52,15 +52,14 @@ Parameters
 
      * - batchSize
        - integer
-       - The maximum number of documents to return in the first batch. By default, the ``find()`` 
-         command has an initial batch size of ``101`` documents. This
-         option can enforce a smaller limit than 16 mebibytes (MiB), but not a larger
+       - The maximum number of documents within each batch returned in a query result. By default, the ``find`` 
+         command has an initial batch size of ``101`` documents and a maximum size of 16 mebibytes (MiB)
+         for each subsequent batch. This option can enforce a smaller limit than 16 mebibytes (MiB), but not a larger
          one. If you set ``batchSize`` to a limit that results in batches larger than
          16 MiB, this option has no effect.
 
          A batchSize of ``0`` means that the cursor will be established, but no documents 
-         will be returned in the first batch. This may be useful for quickly returning a cursor
-         or failure without doing significant server-side work.
+         will be returned in the first batch.
 
          Unlike the previous wire protocol version, a batchSize of ``1`` for the
          :dbcommand:`find` command does not close the cursor.

--- a/source/reference/method/MongoDBCollection-listSearchIndexes.txt
+++ b/source/reference/method/MongoDBCollection-listSearchIndexes.txt
@@ -40,10 +40,13 @@ Parameters
 
      * - batchSize
        - integer
-       - Specifies the batch size for the cursor, which will apply to both the
+       - Specifies the batch size for the cursor, which will apply to both thex
          initial ``aggregate`` command and any subsequent ``getMore`` commands.
-         This determines the maximum number of documents to return in each
-         response from the server.
+         If batchSize is set, ``aggregate`` and any subsequent ``getMore`` commands returns the smaller of ``16`` megabytes of data 
+         or batchSize documents. Operations of type ``find()``, ``aggregate()``, ``listIndexes``, and ``listCollections`` return a maximum of ``16`` megabytes per batch. 
+         batchSize can enforce a smaller limit than ``16`` megabytes, but not a larger one. 
+
+         If batchSize is not set, ``aggregate`` and ``getMore`` commands return up to ``16`` megabytes of data. 
 
          A batchSize of ``0`` is special in that and will only apply to the
          initial ``aggregate`` command; subsequent ``getMore`` commands will use

--- a/source/reference/method/MongoDBCollection-listSearchIndexes.txt
+++ b/source/reference/method/MongoDBCollection-listSearchIndexes.txt
@@ -40,18 +40,16 @@ Parameters
 
      * - batchSize
        - integer
-       - The maximum number of documents within each batch returned in a query result. By default,
-         the ``find()`` method has an initial batch size of ``101`` documents
-         and a maximum of 16 megabytes for each subsequent batch. This
-         option can enforce a smaller limit than 16 megabytes, but not a larger
+       - The maximum number of documents within each batch returned in a query result, which applies 
+         to the ``aggregate`` command. By default, the ``aggregate`` command has an initial batch size of 
+         `101`` documents and a maximum size of 16 mebibytes for each subsequent batch. This
+         option can enforce a smaller limit than 16 mebibytes, but not a larger
          one. If you set ``batchSize`` to a limit that results in batches larger than
-         16 MB, this option has no effect. 
+         16 MiB, this option has no effect.
 
-         A batchSize of ``0`` is special in that and will only apply to the
-         initial ``aggregate`` command; subsequent ``getMore`` commands will use
-         the server's default batch size. This may be useful for quickly
-         returning a cursor or failure from ``aggregate`` without doing
-         significant server-side work.
+         A batchSize of ``0`` means that the cursor will be established, but no documents 
+         will be returned in the first batch. This may be useful for quickly returning a cursor
+         or failure from ``aggregate`` without doing significant server-side work.
 
      * - codec
        - MongoDB\\Codec\\DocumentCodec

--- a/source/reference/method/MongoDBCollection-listSearchIndexes.txt
+++ b/source/reference/method/MongoDBCollection-listSearchIndexes.txt
@@ -40,7 +40,7 @@ Parameters
 
      * - batchSize
        - integer
-       - The maximum number of documents within each batch returned in a query result, which applies 
+       - The maximum number of documents within each batch returned in the indexes list, which applies 
          to the ``aggregate`` command. By default, the ``aggregate`` command has an initial batch size of 
          ``101`` documents and a maximum size of 16 mebibytes (MiB) for each subsequent batch. This
          option can enforce a smaller limit than 16 MiB, but not a larger

--- a/source/reference/method/MongoDBCollection-listSearchIndexes.txt
+++ b/source/reference/method/MongoDBCollection-listSearchIndexes.txt
@@ -42,8 +42,8 @@ Parameters
        - integer
        - The maximum number of documents within each batch returned in a query result, which applies 
          to the ``aggregate`` command. By default, the ``aggregate`` command has an initial batch size of 
-         ``101`` documents and a maximum size of 16 mebibytes for each subsequent batch. This
-         option can enforce a smaller limit than 16 mebibytes, but not a larger
+         ``101`` documents and a maximum size of 16 mebibyte (MiB) for each subsequent batch. This
+         option can enforce a smaller limit than 16 MiB, but not a larger
          one. If you set ``batchSize`` to a limit that results in batches larger than
          16 MiB, this option has no effect.
 

--- a/source/reference/method/MongoDBCollection-listSearchIndexes.txt
+++ b/source/reference/method/MongoDBCollection-listSearchIndexes.txt
@@ -47,10 +47,6 @@ Parameters
          one. If you set ``batchSize`` to a limit that results in batches larger than
          16 MiB, this option has no effect.
 
-         A batchSize of ``0`` means that the cursor will be established, but no documents 
-         will be returned in the first batch. This may be useful for quickly returning a cursor
-         or failure from ``aggregate`` without doing significant server-side work.
-
      * - codec
        - MongoDB\\Codec\\DocumentCodec
        - .. include:: /includes/extracts/collection-option-codec.rst

--- a/source/reference/method/MongoDBCollection-listSearchIndexes.txt
+++ b/source/reference/method/MongoDBCollection-listSearchIndexes.txt
@@ -43,7 +43,7 @@ Parameters
        - Specifies the batch size for the cursor, which will apply to both thex
          initial ``aggregate`` command and any subsequent ``getMore`` commands.
          If batchSize is set, ``aggregate`` and any subsequent ``getMore`` commands returns the smaller of ``16`` megabytes of data 
-         or batchSize documents. Operations of type ``find()``, ``aggregate()``, ``listIndexes``, and ``listCollections`` return a maximum of ``16`` megabytes per batch. 
+         or batchSize documents. Operations of type ``find``, ``aggregate``, ``listIndexes``, and ``listCollections`` return a maximum of ``16`` megabytes per batch. 
          batchSize can enforce a smaller limit than ``16`` megabytes, but not a larger one. 
 
          If batchSize is not set, ``aggregate`` and ``getMore`` commands return up to ``16`` megabytes of data. 

--- a/source/reference/method/MongoDBCollection-listSearchIndexes.txt
+++ b/source/reference/method/MongoDBCollection-listSearchIndexes.txt
@@ -40,13 +40,12 @@ Parameters
 
      * - batchSize
        - integer
-       - Specifies the batch size for the cursor, which will apply to both thex
-         initial ``aggregate`` command and any subsequent ``getMore`` commands.
-         If batchSize is set, ``aggregate`` and any subsequent ``getMore`` commands returns the smaller of ``16`` megabytes of data 
-         or batchSize documents. Operations of type ``find``, ``aggregate``, ``listIndexes``, and ``listCollections`` return a maximum of ``16`` megabytes per batch. 
-         batchSize can enforce a smaller limit than ``16`` megabytes, but not a larger one. 
-
-         If batchSize is not set, ``aggregate`` and ``getMore`` commands return up to ``16`` megabytes of data. 
+       - The maximum number of documents within each batch returned in a query result. By default,
+         the ``find()`` method has an initial batch size of ``101`` documents
+         and a maximum of 16 megabytes for each subsequent batch. This
+         option can enforce a smaller limit than 16 megabytes, but not a larger
+         one. If you set ``batchSize`` to a limit that results in batches larger than
+         16 MB, this option has no effect. 
 
          A batchSize of ``0`` is special in that and will only apply to the
          initial ``aggregate`` command; subsequent ``getMore`` commands will use

--- a/source/reference/method/MongoDBCollection-listSearchIndexes.txt
+++ b/source/reference/method/MongoDBCollection-listSearchIndexes.txt
@@ -42,7 +42,7 @@ Parameters
        - integer
        - The maximum number of documents within each batch returned in a query result, which applies 
          to the ``aggregate`` command. By default, the ``aggregate`` command has an initial batch size of 
-         `101`` documents and a maximum size of 16 mebibytes for each subsequent batch. This
+         ``101`` documents and a maximum size of 16 mebibytes for each subsequent batch. This
          option can enforce a smaller limit than 16 mebibytes, but not a larger
          one. If you set ``batchSize`` to a limit that results in batches larger than
          16 MiB, this option has no effect.

--- a/source/reference/method/MongoDBCollection-listSearchIndexes.txt
+++ b/source/reference/method/MongoDBCollection-listSearchIndexes.txt
@@ -42,7 +42,7 @@ Parameters
        - integer
        - The maximum number of documents within each batch returned in a query result, which applies 
          to the ``aggregate`` command. By default, the ``aggregate`` command has an initial batch size of 
-         ``101`` documents and a maximum size of 16 mebibyte (MiB) for each subsequent batch. This
+         ``101`` documents and a maximum size of 16 mebibytes (MiB) for each subsequent batch. This
          option can enforce a smaller limit than 16 MiB, but not a larger
          one. If you set ``batchSize`` to a limit that results in batches larger than
          16 MiB, this option has no effect.

--- a/source/reference/method/MongoDBDatabase-aggregate.txt
+++ b/source/reference/method/MongoDBDatabase-aggregate.txt
@@ -54,18 +54,16 @@ Parameters
 
      * - batchSize
        - integer
-       - The maximum number of documents within each batch returned in a query result. By default,
-         the ``find()`` method has an initial batch size of ``101`` documents
-         and a maximum of 16 megabytes for each subsequent batch. This
-         option can enforce a smaller limit than 16 megabytes, but not a larger
+       - The maximum number of documents within each batch returned in a query result, which applies 
+         to the ``aggregate`` command. By default, the ``aggregate`` command has an initial batch size of 
+         `101`` documents and a maximum size of 16 mebibytes for each subsequent batch. This
+         option can enforce a smaller limit than 16 mebibytes, but not a larger
          one. If you set ``batchSize`` to a limit that results in batches larger than
-         16 MB, this option has no effect.
-         
-         A batchSize of ``0`` is special in that and will only apply to the
-         initial ``aggregate`` command; subsequent ``getMore`` commands will use
-         the server's default batch size. This may be useful for quickly
-         returning a cursor or failure from ``aggregate`` without doing
-         significant server-side work.
+         16 MiB, this option has no effect.
+
+         A batchSize of ``0`` means that the cursor will be established, but no documents 
+         will be returned in the first batch. This may be useful for quickly returning a cursor
+         or failure from ``aggregate`` without doing significant server-side work.
 
      * - bypassDocumentValidation
        - boolean

--- a/source/reference/method/MongoDBDatabase-aggregate.txt
+++ b/source/reference/method/MongoDBDatabase-aggregate.txt
@@ -56,8 +56,8 @@ Parameters
        - integer
        - The maximum number of documents within each batch returned in a query result.
          By default, the ``aggregate`` command has an initial batch size of 
-         ``101`` documents and a maximum size of 16 mebibytes for each subsequent batch. This
-         option can enforce a smaller limit than 16 mebibytes, but not a larger
+         ``101`` documents and a maximum size of 16 mebibytes (MiB) for each subsequent batch. This
+         option can enforce a smaller limit than 16 MiB, but not a larger
          one. If you set ``batchSize`` to a limit that results in batches larger than
          16 MiB, this option has no effect.
 

--- a/source/reference/method/MongoDBDatabase-aggregate.txt
+++ b/source/reference/method/MongoDBDatabase-aggregate.txt
@@ -56,7 +56,7 @@ Parameters
        - integer
        - The maximum number of documents within each batch returned in a query result.
          By default, the ``aggregate`` command has an initial batch size of 
-         `101`` documents and a maximum size of 16 mebibytes for each subsequent batch. This
+         ``101`` documents and a maximum size of 16 mebibytes for each subsequent batch. This
          option can enforce a smaller limit than 16 mebibytes, but not a larger
          one. If you set ``batchSize`` to a limit that results in batches larger than
          16 MiB, this option has no effect.

--- a/source/reference/method/MongoDBDatabase-aggregate.txt
+++ b/source/reference/method/MongoDBDatabase-aggregate.txt
@@ -54,8 +54,8 @@ Parameters
 
      * - batchSize
        - integer
-       - The maximum number of documents within each batch returned in a query result, which applies 
-         to the ``aggregate`` command. By default, the ``aggregate`` command has an initial batch size of 
+       - The maximum number of documents within each batch returned in a query result.
+         By default, the ``aggregate`` command has an initial batch size of 
          `101`` documents and a maximum size of 16 mebibytes for each subsequent batch. This
          option can enforce a smaller limit than 16 mebibytes, but not a larger
          one. If you set ``batchSize`` to a limit that results in batches larger than

--- a/source/reference/method/MongoDBDatabase-aggregate.txt
+++ b/source/reference/method/MongoDBDatabase-aggregate.txt
@@ -56,8 +56,16 @@ Parameters
        - integer
        - Specifies the batch size for the cursor, which will apply to both the
          initial ``aggregate`` command and any subsequent ``getMore`` commands.
-         This determines the maximum number of documents to return in each
-         response from the server.
+         
+         The ``aggregate`` command has an initial batch size of 101 documents by default.
+         Subsequent ``getMore`` operations issued against the resulting cursor have no default batch size, 
+         so they are limited only by the ``16`` megabyte message size.
+
+         If batchSize is set, ``aggregate`` and any subsequent ``getMore`` commands returns the smaller of 16 megabytes of data 
+         or batchSize documents. Operations of type ``aggregate`` return a maximum of ``16`` megabytes per batch. 
+         batchSize can enforce a smaller limit than ``16`` megabytes, but not a larger one. 
+
+         If batchSize is not set, ``aggregate`` and ``getMore`` commands return up to ``16`` megabytes of data. 
 
          A batchSize of ``0`` is special in that and will only apply to the
          initial ``aggregate`` command; subsequent ``getMore`` commands will use

--- a/source/reference/method/MongoDBDatabase-aggregate.txt
+++ b/source/reference/method/MongoDBDatabase-aggregate.txt
@@ -54,19 +54,13 @@ Parameters
 
      * - batchSize
        - integer
-       - Specifies the batch size for the cursor, which will apply to both the
-         initial ``aggregate`` command and any subsequent ``getMore`` commands.
+       - The maximum number of documents within each batch returned in a query result. By default,
+         the ``find()`` method has an initial batch size of ``101`` documents
+         and a maximum of 16 megabytes for each subsequent batch. This
+         option can enforce a smaller limit than 16 megabytes, but not a larger
+         one. If you set ``batchSize`` to a limit that results in batches larger than
+         16 MB, this option has no effect.
          
-         The ``aggregate`` command has an initial batch size of 101 documents by default.
-         Subsequent ``getMore`` operations issued against the resulting cursor have no default batch size, 
-         so they are limited only by the ``16`` megabyte message size.
-
-         If batchSize is set, ``aggregate`` and any subsequent ``getMore`` commands returns the smaller of 16 megabytes of data 
-         or batchSize documents. Operations of type ``aggregate`` return a maximum of ``16`` megabytes per batch. 
-         batchSize can enforce a smaller limit than ``16`` megabytes, but not a larger one. 
-
-         If batchSize is not set, ``aggregate`` and ``getMore`` commands return up to ``16`` megabytes of data. 
-
          A batchSize of ``0`` is special in that and will only apply to the
          initial ``aggregate`` command; subsequent ``getMore`` commands will use
          the server's default batch size. This may be useful for quickly


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-php-library/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-47835>
Staging - <https://deploy-preview-215--docs-php-library.netlify.app/reference/method/MongoDBCollection-listSearchIndexes/#parameters>
<https://deploy-preview-215--docs-php-library.netlify.app/reference/method/MongoDBDatabase-aggregate/#parameters>
<https://deploy-preview-215--docs-php-library.netlify.app/reference/method/MongoDBCollection-find/#parameters>
<https://deploy-preview-215--docs-php-library.netlify.app/reference/method/MongoDBDatabase-watch/#parameters>
<https://deploy-preview-215--docs-php-library.netlify.app/read/retrieve/#modify-find-behavior>

Note: This topic is a bit over my head in terms of technicalities of the batchsize parameter. I read the slack thread provided in the ticket as well as found the doc that I linked in the ticket about batchsize, but any suggestions about clarity or accuracy are greatly appreciated!

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
- [x] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
