### PR TITLE
[PHP] Backport title change to v1.20

### DIFF
--- a/source/index.txt
+++ b/source/index.txt
@@ -61,8 +61,8 @@ Databases and Collections
 Learn how to use the {+library-short+} to work with MongoDB databases and collections
 in the :ref:`php-databases-collections` section.
 
-Read Data from MongoDB
-----------------------
+Read Data
+---------
 
 Learn how you can retrieve data from MongoDB in the :ref:`php-read` section.
 

--- a/source/read.txt
+++ b/source/read.txt
@@ -1,8 +1,8 @@
 .. _php-read:
 
-======================
-Read Data from MongoDB
-======================
+=========
+Read Data
+=========
 
 .. contents:: On this page
    :local:


### PR DESCRIPTION
[PHP] Remove "MongoDB" from page title

(cherry picked from commit 97960e1e63884908040f238e45db3385c3c2eb3c)

# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-php-library/blob/master/REVIEWING.md)

JIRA - https://jira.mongodb.org/browse/DOCSP-48025
Staging - <https://docs-mongodbcom-staging.corp.mongodb.com/drivers/docsworker-xlarge/NNNNN/>

From https://github.com/mongodb/docs-php-library/pull/218

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
- [ ] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
