### PR TITLE
DOCSP-50735-too-short-title-codecs

### DIFF
--- a/source/data-formats/codecs.txt
+++ b/source/data-formats/codecs.txt
@@ -1,8 +1,8 @@
 .. _php-codecs:
 
-======
-Codecs
-======
+============================
+Encode Data with Type Codecs
+============================
 
 
 .. contents:: On this page


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-php-library/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-50735>

### Staging Links

<!-- start insert-links -->
<li><a href=https://deploy-preview-277--docs-php-library.netlify.app/data-formats/codecs>data-formats/codecs</a></li>
<!-- end insert-links -->

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
- [ ] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
- [ ] Are the page titles greater than 20 characters long and [SEO relevant](https://docs.google.com/spreadsheets/d/1Wkt0-5z04KmcMNscN5bjUKnzwWAtMq9VESp-Lz6r2o8/edit?usp=sharing)?
